### PR TITLE
Add metrics-server

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,6 +14,8 @@ containers:
     resource: node-exporter-image
   kube-state-metrics:
     resource: kube-state-metrics-image
+  metrics-server:
+    resource: metrics-server-image
 
 resources:
   node-exporter-image:
@@ -24,6 +26,10 @@ resources:
     type: oci-image
     description: OCI image for kube-state-metrics (k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0)
     upstream-source: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0
+  metrics-server-image:
+    type: oci-image
+    description: OCI image for metrics-server
+    upstream-source: registry.k8s.io/metrics-server/metrics-server:v0.6.0
 
 provides:
   metrics-endpoint:


### PR DESCRIPTION
## Problem
For the load test, need to be able to get the equivalent of `kubectl top pod`

## Solution
Add metrics-server.

---

> https://github.com/kubernetes/kube-state-metrics should already contain the equivalent of `kubectl top` by default under the `containers_` namespace. I'm not sure whether https://github.com/simskij/kube-metrics-k8s-operator is in a working state or not, but could serve as a starting point (or even just deploying kube-state-metrics manually.

Unfortunately, those metrics (the entire `containers_` namespace, actually, and the baseline requirement for `top pod`) actually comes from [metrics-server](https://github.com/kubernetes-sigs/metrics-server), not `kube-state-metrics`. The closest we can get there is `kube_pod_container_resource_requests`, and that's pretty fuzzy.

The incoherence of the ~~philosophers~~ k8s monitoring. `node_exporter`, `metrics-server`, _and_ `kube-state-metrics` are required to get a full overview. The existing charm only provides 2 out of 3, but `metrics-server` could be a fair addition to get started.

For certs/tokens, I did at least remember that the `kubeconfig` has them, in which case what sort of microk8s we're running doesn't matter, and you can also snatch the token (if RBAC is enabled) out of it. Pulling them out of the kubeconfig (`.clusters.cluster.certificate-authority-data` and `.users.[i].user.token` are just base64ed and are otherwise usable) is probably a good way to go.

_Originally posted by @rbarry82 in https://github.com/canonical/cos-lite-bundle/issues/65#issuecomment-1446233520_

